### PR TITLE
Update URL of Hetzner Cloud API spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is an attempt to improve Hetzner's own OpenAPI specification to make it usable in code generation.
 
 When this project was started, Hetzner had not published their own OpenAPI specification for their cloud API, so I decided to build my own based on the HTML documentation on their website.
-Luckily, Hetzner has actually published an [OpenAPI spec for their API](https://docs.hetzner.cloud/spec.json) in the meantime but I think this project still adds some value.
+Luckily, Hetzner has actually published an [OpenAPI spec for their API](https://docs.hetzner.cloud/cloud.spec.json) in the meantime but I think this project still adds some value.
 
 While Hetzner now appears to generate their documentation website from the OpenAPI spec, the spec is not very useful for automatic code generation.
 This project aims to convert the official spec to an improved version with the following main features:
@@ -21,7 +21,7 @@ As an added benefit, mainly from use of common components, the improved spec is 
 
 - [Link to the generated openAPI document](openapi/hcloud.json)
 - [Official API documentation](https://docs.hetzner.cloud/)
-- [OpenAPI spec document provided by Hetzner](https://docs.hetzner.cloud/spec.json)
+- [OpenAPI spec document provided by Hetzner](https://docs.hetzner.cloud/cloud.spec.json)
 - [OpenAPI standard](https://swagger.io/specification/)
 
 ## Use Cases

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ function parseArgs(): Arguments {
       source: {
         type: "string",
         describe: "URL or local file with OpenAPI spec in JSON",
-        default: "https://docs.hetzner.cloud/spec.json",
+        default: "https://docs.hetzner.cloud/cloud.spec.json",
       },
       output: {
         alias: "o",


### PR DESCRIPTION
This changes the Hetzner Cloud API spec URL to the new location.